### PR TITLE
Change from Gulp to Grunt; Update Getting Started Cheatsheet

### DIFF
--- a/1-getting-started/cheatsheet.md
+++ b/1-getting-started/cheatsheet.md
@@ -16,27 +16,47 @@
     * --save-dev: This is used to save the package for development purpose. Example: unit tests, minification.
 ```
 
-### If using any npm components (gulp/jshint/watch):\
+### If using any npm components (grunt/jshint/watch):\
 ```
     npm init    (answer several questions)
-    npm install gulp --save-dev
+    npm install grunt --save-dev
     npm install jshint --save-dev
-    npm install gulp-jshint --save-dev
+    npm install grunt-contrib-jshint --save-dev
     npm install jshint-stylish --save-dev
-    npm install gulp-watch --save-dev
-    touch gulpfile.js
-    touch .jshintrc
+    npm install grunt-contrib-watch --save-dev
 ```
-
-## Git:
-
-#### Create repo on github.com and copy remote url
+---
+### Git setup:
+#### Create repo on github.com and copy remote url. Then use that url in the commands below
 ```
     git init
-    git remote add origin http://githubURL
+    git remote add origin http://<githubURL>
     touch .gitignore
     touch README.md
 ```
+
+#### Add to README.md
+```
+    What your program does
+    How to pull it down from github and run it
+```
+##### Or at the very least:
+```
+    The name of the app
+```
+
+##### IMPORTANT: Add and commit the README before switching to a new branch to begin creating other files
+```
+git add README.md
+git commit -m "Add README"
+git push -u origin master
+```
+##### This will assure that the master branch doesn't "disappear" when you switch to your new branch
+##### Now switch to a new branch. _Never work on `master`_
+```
+git checkout -b <my-branch>
+```
+---
 
 ### Standard files/dirs:
 ```
@@ -44,6 +64,8 @@
     mkdir styles
     mkdir scripts
     touch js & css files
+    touch Gruntfile.js
+    touch .jshintrc (note the ".")
 ```
 
 ### Add to .gitignore:
@@ -53,25 +75,10 @@
     node_modules
 ```
 
-### Add to README.md:
-```
-    What program does
-    How to install
-```
-
-### Add to gulpfile.js:
+### Add to Gruntfile.js:
 ```
     Example code in Notes
     Change files watched in 2 places to "scripts/*.js"
-```
-
-### Add to .jshintrc:
-    Example code in Notes
-```
-    git add .
-    git commit -m "First Commit"
-    git push -u origin master
-    git checkout -b newBranchName
 ```
 
 ### At the top of all js files:
@@ -79,41 +86,41 @@
     "use strict";
 ```
 
-### In another Terminal tab:
+### Add the basics to .jshintrc:
 ```
-    gulp watch
+{
+  "predef": [ "document", "jQuery", "$", "console" ],
+  "esversion": 6,
+  "globalstrict": true
+}
+```
+
+### Open your Gruntfile.js and paste in the following code:
+```
+module.exports = function(grunt) {
+
+  grunt.initConfig({
+    jshint: {
+      files: ['./javascripts/**/*.js']
+    },
+    watch: {
+      javascripts: {
+        files: ['./javascripts/**/*.js'],
+        tasks: ['jshint']
+      }
+  });
+
+  require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+  grunt.registerTask('default', ['jshint', 'watch']);
+};
+```
+
+### In another Terminal tab run Grunt to run your registered default tasks:
+```
+    grunt
 ```
 
 ### On the command line
 ```
     http-server
-```
-
-### Create your gulpfile.js and paste in the following code:
-```
-    var gulp = require('gulp');
-    var jshint = require('gulp-jshint');
-    var watch = require('gulp-watch');
-
-    gulp.task('default', ['lint', 'watch']);
-
-    gulp.task('watch', function() {
-        gulp.watch('./javascripts/**/*.js', ['lint']);
-    });
-
-    gulp.task('lint', function() {
-        return gulp.src('./javascripts/**/*.js')
-        .pipe(jshint())
-        .pipe(jshint.reporter('jshint-stylish'));
-    });
-```
-
-
-### Set some options for jshint. Create a .jshintrc in your directory and paste in the following configuration object:
-```
-    {
-     "predef": [ "document", "jQuery", "$", "console" ],
-     "esversion": 6,
-     "globalstrict": true
-    }
 ```

--- a/3-single-page-applications/resources/README.md
+++ b/3-single-page-applications/resources/README.md
@@ -27,5 +27,3 @@
 ### [Javascript: XHR](SP_JS_XHR.md)
 
 ### [VIM Overview](SP_VIM_OVERVIEW.md)
-
-### Automatic code validation with [Gulp](SP_GULP.md)

--- a/4-modern-javascript-developer/challenges/MJ_INDIVIDUAL_CHALLENGES.md
+++ b/4-modern-javascript-developer/challenges/MJ_INDIVIDUAL_CHALLENGES.md
@@ -46,7 +46,10 @@ Create a checkers game using only jQuery to manipulate the DOM. Augment your jav
 
 For the truly brave.
 
-Develop a process that lets you automate the running of your unit tests with a Gulp task. You could start by looking at the [gulp-jasmine](https://www.npmjs.com/package/gulp-jasmine) npm package. You'll need Browserify and a few other tools in order to get it working. It will require a lot of Googling and reading articles because it is **not** a straightforward, or easy, task.
+Develop a process that lets you automate the running of your unit tests with a Grunt task. You could start by looking at the [grunt--contrib-jasmine](https://www.npmjs.com/package/grunt-contrib-jasmine) npm package. You'll need Browserify and a few other tools in order to get it working. It will require a lot of Googling and reading articles because it is **not** a straightforward, or easy, task.  
+
+This article may prove helpful:
+[Testing a Browserify Project With Jasmine and Grunt](http://dapperdeveloper.com/2015/01/21/testing-a-browserify-project-with-jasmine-and-grunt/)
 
 <a id="challenge-3"></a>
 # Individual Challenge \#3

--- a/4-modern-javascript-developer/exercises/MJ_BROWSERIFY_PLANETS.md
+++ b/4-modern-javascript-developer/exercises/MJ_BROWSERIFY_PLANETS.md
@@ -9,7 +9,7 @@ mkdir -p ~/workspace/exercises/mjd/solar-system && cd $_
 ```
 
 1. Use `npm` to install Browserify, and any other packages you need to compile your modules.
-2. Make sure you have the Gulp task running that will build the distribution bundle file.
+2. Make sure you have the Grunt task running that will build the distribution bundle file.
 
 ## Instructions
 

--- a/4-modern-javascript-developer/exercises/MJ_BROWSERIFY_SANDWICH_MAKER.md
+++ b/4-modern-javascript-developer/exercises/MJ_BROWSERIFY_SANDWICH_MAKER.md
@@ -12,4 +12,4 @@ mkdir -p ~/workspace/exercises/mjd/sandwich && cd $_
 
 ## Instructions
 
-Convert your Sandwich Maker code to use CommonJS module pattern instead of the IIFE pattern and have a [Gulp task](../resources/BROWSERIFY_GULPFILE.md) for compiling your modules.
+Convert your Sandwich Maker code to use CommonJS module pattern instead of the IIFE pattern and have a [Grunt task](../resources/BROWSERIFY_GRUNTFILE.md) for compiling your modules.

--- a/4-modern-javascript-developer/resources/MJ_BROWSERIFY_CONCEPTS.md
+++ b/4-modern-javascript-developer/resources/MJ_BROWSERIFY_CONCEPTS.md
@@ -137,15 +137,15 @@ module.exports = divide;
 
 Now that you've got all of the modules needed for your application, it's time to stitch them together.
 
-Go ahead and create a `gulpfile.js` in the root directory for your project, and follow the instructions in the [Browserify Gulpfile](./MJ_BROWSERIFY_GULPFILE.md) resource file.
+Go ahead and create a `Gruntfile.js` in the root directory for your project, and follow the instructions in the [Browserify Gruntfile](./MJ_BROWSERIFY_GRUNTFILE.md) resource file.
 
-Once all the packages are installed and your Gulp file has the instructions, you can try to build your application. Go to the CLI in the root project folder and run the following command.
+Once all the packages are installed and your Grunt file has the instructions, you can try to build your application. Go to the CLI in the root project folder and run the following command.
 
 ```bash
-gulp
+grunt
 ```
 
-This will create a `bundle.js` file in the `dist` folder. If you encounter any error when Gulp runs, or the bundle file does not get created, talk to an instructor.
+This will create a `bundle.js` file in the `dist` folder. If you encounter any error when Grunt runs, or the bundle file does not get created, talk to an instructor.
 
 ## Running your application
 

--- a/4-modern-javascript-developer/resources/MJ_GRUNT_SETUP.md
+++ b/4-modern-javascript-developer/resources/MJ_GRUNT_SETUP.md
@@ -2,14 +2,16 @@
 
 ## Install Grunt
 
-Talk about what Grunt does for modern front end developers.
+Grunt is a widely used task runner tool. It can be configured to handle a number of jobs for you.
 
  * Checking code for errors
- * Uglify code
+ * Uglify code (minifying it by removing all the white space)
  * Concatenate files
  * Other cool stuff
 
-Run the command `which grunt`. You should see the output `/usr/local/bin/grunt`.  If you don't, execute the following command in yor Vagrant machine `sudo npm install grunt-cli -g`.
+ It's like a second set of hands to do necessary, but boring and repetitive tasks that needs to happen when building a modern application.
+
+Run the command `which grunt`. If you see the output `/usr/local/bin/grunt`, your instructor planned ahead and had you install it earlier. You're good to go. If not, you need to install the Grunt command line interface: `npm install -g grunt-cli`
 
 ## Working with 3rd Party Libraries
 
@@ -77,7 +79,7 @@ module.exports = function(grunt) {
 
 
   // Set up the default Grunt task. The default task is executed
-  // when you type `grunt`, without any additional parameters in the 
+  // when you type `grunt`, without any additional parameters in the
   // command line.
   grunt.registerTask('default', ['jshint']);
 };

--- a/4-modern-javascript-developer/resources/README.md
+++ b/4-modern-javascript-developer/resources/README.md
@@ -4,7 +4,7 @@
 
 ### [AJAX](MJ_JQUERY_AJAX.md)
 
-### [Browserify & Gulpfile](MJ_BROWSERIFY_GULPFILE.md)
+### [Browserify & Gruntfile](MJ_BROWSERIFY_GRUNTFILE.md)
 
 ### [Introduction to jQuery](MJ_JQUERY_INTRODUCTION.md)
 


### PR DESCRIPTION
Removes references to Gulp and changes to Grunt (except where Gulp is used as an alternative resource to Grunt). 
Note: Still TODO -- Add `MJ_BROWSERIFY_GRUNTFILE.md` with a sample Gruntfile boilerplate