### PR TITLE
Fixed typo in SW_PLANNING.md

### DIFF
--- a/2-the-static-web/resources/SW_JS_IF_SWITCH_FOR.md
+++ b/2-the-static-web/resources/SW_JS_IF_SWITCH_FOR.md
@@ -29,10 +29,13 @@ var value = 10;
 switch (value) {
   case 1:
     console.log("Small number");
+    break;
   case 5:
     console.log("Medium number");
-  case 1:
+    break;
+  case 10:
     console.log("Large number");
+    break;
   default:
     console.log("Dunno");
 }

--- a/2-the-static-web/resources/SW_PLANNING.md
+++ b/2-the-static-web/resources/SW_PLANNING.md
@@ -1,6 +1,6 @@
 # How to plan an application
 
-Talk with students about what steps need to be taken before you write a single line of code for an applcation.
+Talk with students about what steps need to be taken before you write a single line of code for an application.
 
 1. Gathering acceptance criteria
 1. Whiteboarding designs


### PR DESCRIPTION
Typo fixed [here](https://github.com/nashville-software-school/front-end-milestones/blob/master/2-the-static-web/resources/SW_PLANNING.md): `applcation` --> `application`

Also fixed a switch statement found [here](https://github.com/nashville-software-school/front-end-milestones/blob/master/2-the-static-web/resources/SW_JS_IF_SWITCH_FOR.md) where the current code is buggy:

``` javascript
var value = 10;
switch (value) {
  case 1:
    console.log("Small number");
  case 5:
    console.log("Medium number");
  case 1:
    console.log("Large number");
  default:
    console.log("Dunno");
}
```

The switch block has two `case 1` scenarios. Also, if `value` were set to 1, all cases would fire. Added `break;` lines at the end of each case in the PR.
