### PR TITLE
minor typo and grammar fixes

### DIFF
--- a/3-single-page-applications/resources/SP_GIT_ADVANCED.md
+++ b/3-single-page-applications/resources/SP_GIT_ADVANCED.md
@@ -4,7 +4,7 @@
 
 You're going to learn how to [rebase](https://www.git-scm.com/book/en/v2/Git-Branching-Rebasing) branches instead of merging them.
 
-In a merge, git performs a three-way diff between the branch you are merging, you're current branch, and the common ancestor where the branch occurred. In a rebase, git takes all of the commits on another branch, and replay them, one by one, onto your current branch.
+In a merge, git performs a three-way diff between the branch you are merging, your current branch, and the common ancestor where the branch occurred. In a rebase, git takes all of the commits on another branch, and replays them, one by one, onto your current branch.
 
 Let's try it out
 


### PR DESCRIPTION
Changed "you're current branch" to "_your_ current branch".
Changed "and replay them, one by one" to "and _replays_ them, one by one"