### PR TITLE
Corrected broken link for blog exercise in Resources Readme

### DIFF
--- a/1-the-static-web/resources/SW_HTML_101.md
+++ b/1-the-static-web/resources/SW_HTML_101.md
@@ -1,6 +1,6 @@
 # :pushpin: Exercises
 
-1. [Blog](../exercises/SW_HTML_BLOG.md)
+1. [Blog](../exercises/SW_HTML_BLOG_01.md)
 1. [Personal Bio](../exercises/SW_HTML_PERSONAL_BIO.md)
 1. [Banking Form](../exercises/SW_HTML_BANKING_FORM.md)
 


### PR DESCRIPTION
Looks like Blog file name was changed at some point, corrected broken link in markdown for Static Web Resources.