### PR TITLE
Minor edit to Sublime Text alias markdown

### DIFF
--- a/1-the-static-web/resources/SW_SUBLIME_ALIAS.md
+++ b/1-the-static-web/resources/SW_SUBLIME_ALIAS.md
@@ -19,7 +19,7 @@ The alias we're going to set up will allow us to navigate to a directory and sim
 ### Windows / Git-Bash Version
 1. Open Git-Bash, make sure your working directory is your home directory. If you type `pwd`, you should see something like `/c/Users/yourusernamehere` .
 2. Create a file named `.bash_profile` in this directory and open this file in Sublime Text.
-3. Paste the following in that file : `alias subl='C:/Program\ Files/Sublime\ Text\ 3/sublime_text.exe'`
+3. Paste the following in that file : `alias subl='C:/Program\ Files/Sublime\ Text\ 3/sublime_text.exe'` Note: This file path is where Sublime Text is typically installed by default. If you've changed this, you'll have to edit the path to point wherever sublime_text.exe is installed on your machine.
 4. Save this file and exit Git-Bash, restart Git-Bash
 5. Navigate to an exercise directory you want to open in Sublime Text and type `subl .` -- This should open the entire directory in Sublime Text.
 


### PR DESCRIPTION
Added comment about Sublime Text's default install path, this could differ depending on how student installs ST, causing alias to not work as intended.