### PR TITLE
Fixed Small Typo in RBA Exercises

### DIFF
--- a/4-rich-browser-applications/exercises/README.md
+++ b/4-rich-browser-applications/exercises/README.md
@@ -5,7 +5,7 @@
 
 
 ### [Handlebars](../resources/RBA_HANDLEBARS.md)
-1. [Best Blog Every](RBA_HANDLEBARS_BLOG.md) - Handlebars, GRUNT, SASS, Browserify
+1. [Best Blog Ever](RBA_HANDLEBARS_BLOG.md) - Handlebars, GRUNT, SASS, Browserify
 
 
 ### [API](../resources/RBA_API_CONCEPTS.md)


### PR DESCRIPTION
'Best Blog Ever' exercise was formally titled 'Best Blog Every'.